### PR TITLE
Empty Cart bad product

### DIFF
--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -2,8 +2,14 @@ import { getLocalStorage } from "./utils.mjs";
 
 function renderCartContents() {
   const cartItems = getLocalStorage("so-cart");
-  const htmlItems = cartItems.map((item) => cartItemTemplate(item));
-  document.querySelector(".product-list").innerHTML = htmlItems.join("");
+  if (localStorage.getItem("so-cart") === null){  // if there are no items in the cart
+    const emptyCartMessage = document.createElement("h3");
+    emptyCartMessage.innerHTML = "You Have No Items In Your Cart";
+    document.getElementsByTagName("main")[0].appendChild(emptyCartMessage);
+  }else{
+    const htmlItems = cartItems.map((item) => cartItemTemplate(item));
+    document.querySelector(".product-list").innerHTML = htmlItems.join("");
+  }
 }
 
 function cartItemTemplate(item) {

--- a/src/product_pages/northface-talus-4.html
+++ b/src/product_pages/northface-talus-4.html
@@ -78,7 +78,7 @@
         </p>
 
         <div class="product-detail__add">
-          <button id="addToCart" data-id="989CG">Add to Cart</button>
+          <button id="addToCart" data-id="985RF">Add to Cart</button>
         </div>
       </section>
     </main>


### PR DESCRIPTION
cart page now displays empty cart message when no items are in the cart. Also fixed a bad link on one of the products that was calling the incorrect product ID causing wrong details to be shown on the cart page.